### PR TITLE
pam-test: set PAM_RUSER when running an auth test and allow skipping stack config checks

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -177,13 +177,14 @@ int main(int argc, const char *argv[])
 
     user = argv[2];
 
-    /* PAM Stack for the service must exist. */
-    if(access("/etc/pam.d/" PAM_TEST_SERVICE, F_OK) != 0) {
+    if (!getenv("PAM_SKIP_CHECK_CONFIG")) {
+      /* PAM Stack for the service must exist. */
+      if(access("/etc/pam.d/" PAM_TEST_SERVICE, F_OK) != 0) {
         fprintf(stderr, PAM_TEST_STACK " does not exist!\n");
         return 1;
+      }
+      print_pam_stack(PAM_TEST_STACK);
     }
-
-    print_pam_stack(PAM_TEST_STACK);
 
     op = parse_operation(argv[1]);
     switch (op) {

--- a/src/main.c
+++ b/src/main.c
@@ -90,7 +90,7 @@ static int test_auth(const char *user)
     ret = pam_start(PAM_TEST_SERVICE, user, &conv, &pamh);
     CHECK_PAM_STATUS("pam_start", pamh, ret, msgs, i, done);
 
-	ret = pam_set_item(pamh, PAM_RUSER, strdup(getlogin()));
+	ret = pam_set_item(pamh, PAM_RUSER, strdup(cuserid(NULL)));
 	CHECK_PAM_STATUS("pam_set_item:PAM_RUSER", pamh, ret, msgs, i, done);
 
     ret = pam_authenticate(pamh, 0);

--- a/src/main.c
+++ b/src/main.c
@@ -22,6 +22,7 @@
 #include <security/pam_appl.h>
 #include <security/pam_misc.h>
 #include <stdio.h>
+#include <unistd.h>
 
 #define PAM_TEST_SERVICE "pam_test"
 #define PAM_TEST_STACK "/etc/pam.d/" PAM_TEST_SERVICE
@@ -88,6 +89,9 @@ static int test_auth(const char *user)
 
     ret = pam_start(PAM_TEST_SERVICE, user, &conv, &pamh);
     CHECK_PAM_STATUS("pam_start", pamh, ret, msgs, i, done);
+
+	ret = pam_set_item(pamh, PAM_RUSER, strdup(getlogin()));
+	CHECK_PAM_STATUS("pam_set_item:PAM_RUSER", pamh, ret, msgs, i, done);
 
     ret = pam_authenticate(pamh, 0);
     CHECK_PAM_STATUS("pam_authenticate", pamh, ret, msgs, i, done);


### PR DESCRIPTION
PAM_RUSER is important in contexts where a local user is escalating to a higher-privilege local user (e.g. su, sudo). Modules like pam_ssh_agent_auth rely on it to drop their privileges to those of the requesting user when accessing files.

Also, I'm testing my auth module under pam_wrapper (https://cwrap.org/pam_wrapper.html) and this allows using an alternative config. This PR includes another commit to allow optionally skipping the stack config checks.

Happy to unbundle these 2 changes if you'd rather I do that.